### PR TITLE
replaced `trait TimeZone` with `enum TimeZone`

### DIFF
--- a/examples/now.rs
+++ b/examples/now.rs
@@ -2,7 +2,7 @@ extern crate datetime;
 extern crate locale;
 use datetime::format::DateFormat;
 use datetime::local::LocalDateTime;
-use datetime::zoned::{VariableOffset, TimeZone};
+use datetime::zoned::TimeZone;
 
 use std::path::Path;
 use std::env;
@@ -12,7 +12,7 @@ fn main() {
     let now = LocalDateTime::now();
     println!("It is {} in UTC", format.format(&now, &locale::Time::english()));
 
-    let localtime = match VariableOffset::localtime() {
+    let localtime = match TimeZone::localtime() {
         Ok(t) => t,
         Err(e) => { println!("Error: {}", e); return },
     };
@@ -22,7 +22,7 @@ fn main() {
 
     for arg in env::args().skip(1) {
         let path = Path::new(&arg);
-        let localtime = match VariableOffset::zoneinfo(&path) {
+        let localtime = match TimeZone::zoneinfo(&path) {
             Ok(t) => t,
             Err(e) => { println!("Error: {}", e); continue },
         };

--- a/src/zoned.rs
+++ b/src/zoned.rs
@@ -10,22 +10,119 @@ use std::error::Error;
 use duration::Duration;
 use tz::{Transition, parse};
 
+/// A **time zone** is used to calculate how much to adjust a UTC-based time
+/// based on its geographical location.
+#[derive(Clone,Debug)]
+pub enum TimeZone
+{
+    UTC,
+    FixedOffset{offset: i32},
+    VariableOffset{ transitions: Vec<Transition>}
+}
 
 /// A **time zone** is used to calculate how much to adjust a UTC-based time
 /// based on its geographical location.
-pub trait TimeZone: Clone {
+impl TimeZone
+{
+    fn adjust(&self, local: LocalDateTime) -> LocalDateTime
+    {
+        match self{
+            &TimeZone::UTC => { self.adjust_utc(local)},
+            &TimeZone::FixedOffset{offset} => { self.adjust_fixed(offset, local)},
+            &TimeZone::VariableOffset{ref transitions} => { self.adjust_variable(&transitions, local)},
+        }
+    }
 
-    /// Adjust this local time by a number of seconds.
-    ///
-    /// Although the return value is a `LocalDateTime`, this actual type is
-    /// never exposed.
-    fn adjust(&self, local: LocalDateTime) -> LocalDateTime;
+    fn adjust_utc(&self, local: LocalDateTime) -> LocalDateTime
+    {
+        local  // No adjustment needed! LocalDateTime uses UTC.
+    }
 
-    /// Create a `ZonedDateTime` instance using a clone of this time zone.
-    fn at(&self, local: LocalDateTime) -> ZonedDateTime<Self> {
+    fn adjust_fixed(&self, offset:i32,  local: LocalDateTime) -> LocalDateTime
+    {
+        local + Duration::of(offset as i64)
+    }
+
+    fn adjust_variable(&self, transitions:&Vec<Transition>, local: LocalDateTime) -> LocalDateTime
+    {
+        let unix_timestamp = local.to_instant().seconds() as i32;
+
+        // TODO: Replace this with a binary search
+        match transitions.iter().find(|t| t.timestamp < unix_timestamp) {
+            None     => local,
+            Some(t)  => local + Duration::of(t.local_time_type.offset as i64),
+        }
+    }
+
+    pub fn at(&self, local: LocalDateTime) -> ZonedDateTime
+    {
         ZonedDateTime {
             local: local,
             time_zone: self.clone()
+        }
+    }
+
+    /// Read time zone information in from the user's local time zone.
+    pub fn localtime() -> Result<TimeZone, Box<Error>>
+    {
+        // TODO: replace this with some kind of factory.
+        // this won't be appropriate for all systems
+        TimeZone::zoneinfo(&Path::new("/etc/localtime"))
+    }
+
+    /// Read time zone information in from the file at the given path,
+    /// returning a variable offset containing time transitions if successful,
+    /// or an error if not.
+    pub fn zoneinfo(path: &Path) -> Result<TimeZone, Box<Error>>
+    {
+        let mut contents = Vec::new();
+        try!(File::open(path).unwrap().read_to_end(&mut contents));
+        let mut tz = try!(parse(contents));
+
+        // Sort the transitions *backwards* to make it easier to get the first
+        // one *after* a specified time.
+        tz.transitions.sort_by(|b, a| a.timestamp.cmp(&b.timestamp));
+
+        Ok(TimeZone::VariableOffset{ transitions: tz.transitions })
+    }
+    /// Create a new fixed-offset timezone with the given number of seconds.
+    ///
+    /// Panics if the number of seconds is greater than one day's worth of
+    /// seconds (86400) in either direction.
+    pub fn of_seconds(seconds: i32) -> TimeZone
+    {
+        if seconds <= -86400 || seconds >= 86400 {
+            panic!("Seconds offset greater than one day ({})", seconds)
+        }
+        else {
+            TimeZone::FixedOffset{ offset: seconds }
+        }
+    }
+
+    /// Create a new fixed-offset timezone with the given number of hours and
+    /// minutes.
+    ///
+    /// The values should either be both positive or both negative.
+    ///
+    /// Panics if the numbers are greater than their unit allows (more than 23
+    /// hours or 59 minutes) in either direction, or if the values differ in
+    /// sign (such as a positive number of hours with a negative number of
+    /// minutes).
+    pub fn of_hours_and_minutes(hours: i8, minutes: i8) -> TimeZone
+    {
+        if hours.signum() != minutes.signum() {
+            panic!("Hour and minute values differ in sign ({} and {}", hours, minutes);
+        }
+        else if hours <= -24 || hours >= 24 {
+            panic!("Hours offset greater than one day ({})", hours);
+        }
+        else if minutes <= -60 || minutes >= 60 {
+            panic!("Minutes offset greater than one hour ({})", minutes);
+        }
+        else {
+            let hours = hours as i32;
+            let minutes = minutes as i32;
+            TimeZone::of_seconds(hours * 24 + minutes * 60)
         }
     }
 }
@@ -33,12 +130,14 @@ pub trait TimeZone: Clone {
 
 /// A time paired with a time zone.
 #[derive(Debug, Clone)]
-pub struct ZonedDateTime<TZ> {
+pub struct ZonedDateTime
+{
     local: LocalDateTime,
-    time_zone: TZ,
+    time_zone: TimeZone,
 }
 
-impl<TZ> DatePiece for ZonedDateTime<TZ> where TZ: TimeZone {
+impl DatePiece for ZonedDateTime
+{
     fn year(&self) -> i64 {
         self.time_zone.adjust(self.local).year()
     }
@@ -60,7 +159,7 @@ impl<TZ> DatePiece for ZonedDateTime<TZ> where TZ: TimeZone {
     }
 }
 
-impl<TZ> TimePiece for ZonedDateTime<TZ> where TZ: TimeZone {
+impl TimePiece for ZonedDateTime{
     fn hour(&self) -> i8 {
         self.time_zone.adjust(self.local).hour()
     }
@@ -79,178 +178,37 @@ impl<TZ> TimePiece for ZonedDateTime<TZ> where TZ: TimeZone {
 }
 
 
-/// **Coordinated Universal Time** is the time standard that regulates time
-/// across the world. It does not respect daylight saving time, or undergo any
-/// historical or political changes, which makes it suitable for using as the
-/// 'base time zone' when the actual time zone is not known or relevant.
-#[derive(Debug, Clone)]
-pub struct UTC;
-
-impl TimeZone for UTC {
-    fn adjust(&self, local: LocalDateTime) -> LocalDateTime {
-        local  // No adjustment needed! LocalDateTime uses UTC.
-    }
-}
-
-
-/// A time zone with a **fixed offset** differs from UTC by a given number of
-/// seconds. This is usually given in hours, but occasionally minutes are also
-/// specified.
-#[derive(Debug, Clone)]
-pub struct FixedOffset {
-    offset: i32,
-}
-
-impl FixedOffset {
-
-    /// Create a new fixed-offset timezone with the given number of seconds.
-    ///
-    /// Panics if the number of seconds is greater than one day's worth of
-    /// seconds (86400) in either direction.
-    pub fn of_seconds(seconds: i32) -> FixedOffset {
-        if seconds <= -86400 || seconds >= 86400 {
-            panic!("Seconds offset greater than one day ({})", seconds)
-        }
-        else {
-            FixedOffset { offset: seconds }
-        }
-    }
-
-    /// Create a new fixed-offset timezone with the given number of hours and
-    /// minutes.
-    ///
-    /// The values should either be both positive or both negative.
-    ///
-    /// Panics if the numbers are greater than their unit allows (more than 23
-    /// hours or 59 minutes) in either direction, or if the values differ in
-    /// sign (such as a positive number of hours with a negative number of
-    /// minutes).
-    pub fn of_hours_and_minutes(hours: i8, minutes: i8) -> FixedOffset {
-        if hours.signum() != minutes.signum() {
-            panic!("Hour and minute values differ in sign ({} and {}", hours, minutes);
-        }
-        else if hours <= -24 || hours >= 24 {
-            panic!("Hours offset greater than one day ({})", hours);
-        }
-        else if minutes <= -60 || minutes >= 60 {
-            panic!("Minutes offset greater than one hour ({})", minutes);
-        }
-        else {
-            let hours = hours as i32;
-            let minutes = minutes as i32;
-            FixedOffset::of_seconds(hours * 24 + minutes * 60)
-        }
-    }
-}
-
-impl TimeZone for FixedOffset {
-    fn adjust(&self, local: LocalDateTime) -> LocalDateTime {
-        local + Duration::of(self.offset as i64)
-    }
-}
-
-
-/// A time zone with a **variable offset** differs from UTC by a variable
-/// amount that depends on the date, such as for political reasons when a
-/// country decides to change. By encoding all the transitions, it's possible
-/// to adjust times *after* the transition time while leaving the dates
-/// *before* it unaffected.
-#[derive(Debug, Clone)]
-pub struct VariableOffset {
-    transitions: Vec<Transition>,
-}
-
-impl VariableOffset {
-
-    /// Read time zone information in from the user's local time zone.
-    pub fn localtime() -> Result<VariableOffset, Box<Error>> {
-        // TODO: replace this with some kind of factory.
-        // this won't be appropriate for all systems
-        VariableOffset::zoneinfo(&Path::new("/etc/localtime"))
-    }
-
-    /// Read time zone information in from the file at the given path,
-    /// returning a variable offset containing time transitions if successful,
-    /// or an error if not.
-    pub fn zoneinfo(path: &Path) -> Result<VariableOffset, Box<Error>> {
-        let mut contents = Vec::new();
-        try!(File::open(path).unwrap().read_to_end(&mut contents));
-        let mut tz = try!(parse(contents));
-
-        // Sort the transitions *backwards* to make it easier to get the first
-        // one *after* a specified time.
-        tz.transitions.sort_by(|b, a| a.timestamp.cmp(&b.timestamp));
-
-        Ok(VariableOffset { transitions: tz.transitions })
-    }
-}
-
-impl TimeZone for VariableOffset {
-    fn adjust(&self, local: LocalDateTime) -> LocalDateTime {
-        let unix_timestamp = local.to_instant().seconds() as i32;
-
-        // TODO: Replace this with a binary search
-        match self.transitions.iter().find(|t| t.timestamp < unix_timestamp) {
-            None     => local,
-            Some(t)  => local + Duration::of(t.local_time_type.offset as i64),
-        }
-    }
-}
-
-
-/// An enum of anything that could be a time zone, for cases when you don't
-/// know in advance which type of time zone you'll need.
-#[derive(Debug, Clone)]
-pub enum AnyTimeZone {
-    UTC(UTC),
-    Fixed(FixedOffset),
-    Variable(VariableOffset),
-}
-
-impl TimeZone for AnyTimeZone {
-    fn adjust(&self, local: LocalDateTime) -> LocalDateTime {
-        use self::AnyTimeZone::*;
-
-        match self {
-            &UTC(ref utc)     => utc.adjust(local),
-            &Fixed(ref f)     => f.adjust(local),
-            &Variable(ref v)  => v.adjust(local),
-        }
-    }
-}
-
-
 #[cfg(test)]
 mod test {
-    use super::FixedOffset;
+    use super::TimeZone;
 
-	#[test]
-	fn fixed_seconds() {
-		FixedOffset::of_seconds(1234);
-	}
+    #[test]
+    fn fixed_seconds() {
+        TimeZone::of_seconds(1234);
+    }
 
-	#[test] #[should_panic]
-	fn fixed_seconds_panic() {
-	    FixedOffset::of_seconds(100_000);
-	}
+    #[test] #[should_panic]
+    fn fixed_seconds_panic() {
+        TimeZone::of_seconds(100_000);
+    }
 
-	#[test]
-	fn fixed_hm() {
-	    FixedOffset::of_hours_and_minutes(5, 30);
-	}
+    #[test]
+    fn fixed_hm() {
+        TimeZone::of_hours_and_minutes(5, 30);
+    }
 
-	#[test]
-	fn fixed_hm_negative() {
-	    FixedOffset::of_hours_and_minutes(-3, -45);
-	}
+    #[test]
+    fn fixed_hm_negative() {
+        TimeZone::of_hours_and_minutes(-3, -45);
+    }
 
-	#[test] #[should_panic]
-	fn fixed_hm_panic() {
-	    FixedOffset::of_hours_and_minutes(8, 60);
-	}
+    #[test] #[should_panic]
+    fn fixed_hm_panic() {
+        TimeZone::of_hours_and_minutes(8, 60);
+    }
 
-	#[test] #[should_panic]
-	fn fixed_hm_signs() {
-	    FixedOffset::of_hours_and_minutes(-4, 30);
-	}
+    #[test] #[should_panic]
+    fn fixed_hm_signs() {
+        TimeZone::of_hours_and_minutes(-4, 30);
+    }
 }


### PR DESCRIPTION
Hi, there. When I though of an enum for TimeZone I rather imagined replacing the trait TimeZone all together. I think this would make for a much nicer API, since LocalDateTime and ZonedDateTime could now be initiated almost the same way. I haven't done any benchmarking here yet, but all the tests this work.
What do you think about this kind of implementation?